### PR TITLE
adiciona docker no projeto e tasks do gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
 
     id("io.gitlab.arturbosch.detekt") version "1.16.0"
+    id("com.palantir.docker") version "0.32.0"
 }
 
 allprojects {
@@ -109,5 +110,18 @@ dependencies {
     implementation(project(":privacy"))
     implementation(project(":restaurants"))
     implementation(project(":timetable"))
+}
+
+tasks.named("docker") {
+    dependsOn(":installBootDist")
+}
+
+docker {
+    name = "${project.name}:${project.version}"
+    setDockerfile(project.file("docker/Dockerfile"))
+
+    files(tasks.installBootDist)
+    copySpec.from("docker/resources").into("resources")
+    buildArgs(mapOf("JAR_PATH" to "resources/lib/jopiter-backend.jar"))
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:11-jre-slim
+
+WORKDIR /opt/jopiter-backend
+ENTRYPOINT ["/opt/jopiter-backend/entrypoint.sh"]
+ENV APPLICATION_HOME=/opt/jopiter-backend
+
+ARG VERSION
+ARG JAR_PATH
+ENV APP_VERSION=${VERSION}
+
+ADD resources /opt/jopiter-backend
+ADD ${JAR_PATH} /opt/jopiter-backend/app.jar

--- a/docker/resources/entrypoint.sh
+++ b/docker/resources/entrypoint.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+set -e
+
+JMX_OPTS="${JMX_OPTS:--XX:+UnlockCommercialFeatures -XX:+FlightRecorder -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=9090}"
+
+exec java \
+          $APPLICATION_HEAP_OPTS \
+          $APPLICATION_JMX_OPTS \
+          $APPLICATION_JAVA_OPTS \
+          -jar "$APPLICATION_HOME/app.jar" \
+          $*


### PR DESCRIPTION
# To Test
Execute a task `docker` do gradle, adicionada pelo plugin: `id("com.palantir.docker") version "0.32.0"`

- [ ] A imagem Docker deve ser gerada com sucesso (`docker image ls | grep jopiter`)